### PR TITLE
Default view fallback broken

### DIFF
--- a/Products/CMFDynamicViewFTI/browserdefault.py
+++ b/Products/CMFDynamicViewFTI/browserdefault.py
@@ -96,7 +96,7 @@ class BrowserDefaultMixin(Base):
         fti = self.getTypeInfo()
         if fti is None:
             return None
-        return fti.getViewMethod(self)
+        return fti.getViewMethod(self, **kw)
 
     @security.public
     def canSetDefaultPage(self):

--- a/Products/CMFDynamicViewFTI/fti.py
+++ b/Products/CMFDynamicViewFTI/fti.py
@@ -150,7 +150,10 @@ class DynamicViewTypeInformation(FactoryTypeInformation):
         if check_exists:
             method = getattr(context, layout, None)
             if method is None:
-                return default
+                # maybe it is a view?
+                view = context.unrestrictedTraverse(layout, None)
+                if not view:
+                    return default
         return layout
 
     @security.protected(View)

--- a/Products/CMFDynamicViewFTI/tests/test_fti.py
+++ b/Products/CMFDynamicViewFTI/tests/test_fti.py
@@ -190,6 +190,15 @@ class TestFTI(CMFDVFTITestCase.CMFDVFTITestCase):
         info = self.types.getTypeInfo(dynfolder)
         self.assertEqual(info.getDefaultPage(dynfolder), None)
 
+    def test_DefaultViewWithBadLayoutUseFallback(self):
+        dynfolder = self._makeOne()
+        dynfolder.layout = 'bad_view'
+        info = self.types.getTypeInfo(dynfolder)
+        self.assertEqual(
+            info.defaultView(dynfolder),
+            'index_html'
+        )
+
 
 if six.PY2:
     # I have no idea what is or should be happending here.

--- a/Products/CMFDynamicViewFTI/tests/test_fti.py
+++ b/Products/CMFDynamicViewFTI/tests/test_fti.py
@@ -2,7 +2,6 @@
 from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import TEST_USER_PASSWORD
 from Products.CMFCore.interfaces import ITypeInformation
-from Products.CMFCore.utils import getToolByName
 from Products.CMFDynamicViewFTI.fti import DynamicViewTypeInformation
 from Products.CMFDynamicViewFTI.interfaces import IDynamicViewTypeInformation
 from Products.CMFDynamicViewFTI.tests import CMFDVFTITestCase
@@ -194,11 +193,18 @@ class TestFTI(CMFDVFTITestCase.CMFDVFTITestCase):
         dynfolder = self._makeOne()
         dynfolder.layout = 'bad_view'
         info = self.types.getTypeInfo(dynfolder)
+        # fallback not returned if not activated
+        self.assertFalse(info.default_view_fallback)
         self.assertEqual(
             info.defaultView(dynfolder),
-            'index_html'
+            'bad_view'
         )
-
+        # enable fallback
+        info.default_view_fallback = True
+        self.assertEqual(
+            info.defaultView(dynfolder),
+            info.default_view
+        )
 
 if six.PY2:
     # I have no idea what is or should be happending here.

--- a/news/16.bugfix
+++ b/news/16.bugfix
@@ -1,0 +1,1 @@
+Fixed fallback to default view. [gbastien]


### PR DESCRIPTION
Hi @mauritsvanrees 

I do not know exactly how to handle this as this test is failing for now.

I will propose a PR in CMFPlone also, maybe the PR in CMFPlone must be merged first so this test pass?

https://github.com/plone/Products.CMFDynamicViewFTI/issues/16

See also https://github.com/plone/Products.CMFPlone/issues/2645

For information, this was discovered during PloneConf training about Volto where we can set a layout on the Volto side that corresponds to a React view but that could not exist in Plone backend.

Gauthier